### PR TITLE
Loosen up Jedi version requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -33,7 +33,7 @@ requirements:
     - pybind11_json >=0.2.2,<0.3
   run:
     - python
-    - jedi >=0.15.1,<0.16
+    - jedi >=0.15.1,<0.18
     - pygments >=2.3.1,<3.0.0
     - ptvsd                        # [win and py<38]
     - ptvsd                        # [unix]


### PR DESCRIPTION
See: https://github.com/conda-forge/xeus-python-feedstock/issues/77
