### PR TITLE
Move debugpy to a run_constraint instead of an hard dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [(win and vc<14) or py==36]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -37,8 +37,9 @@ requirements:
   run:
     - python
     - xeus-python-shell >=0.1.5,<0.3
-    - debugpy >=1.1.0,<2.0  # [py>=37]
     - pygments >=2.3.1,<3
+  run_constrained:
+    - debugpy >=1.1.0,<2.0  # [py>=37]
 
 test:
   commands:


### PR DESCRIPTION
This is an optional dependency now (since 0.3.0) for jupyterlite support