### PR TITLE
Simplify build.sh to remove arch and mtune options that are removed from the cmake

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,19 +1,9 @@
 #!/bin/bash
 
-if [[ ${target_platform} == linux-ppc64le ]]; then
-  cmake -DCMAKE_BUILD_TYPE=Release     \
-        -DCMAKE_INSTALL_PREFIX=$PREFIX \
-        -DXPYT_DISABLE_TUNE_GENERIC=ON \
-        -DCMAKE_INSTALL_LIBDIR=lib     \
-        -DPYTHON_EXECUTABLE=$PYTHON    \
-        $SRC_DIR
-else
-  cmake -DCMAKE_BUILD_TYPE=Release     \
-        -DCMAKE_INSTALL_PREFIX=$PREFIX \
-        -DXPYT_DISABLE_ARCH_NATIVE=ON  \
-        -DCMAKE_INSTALL_LIBDIR=lib     \
-        -DPYTHON_EXECUTABLE=$PYTHON    \
-        $SRC_DIR
-fi
+cmake -DCMAKE_BUILD_TYPE=Release     \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib     \
+      -DPYTHON_EXECUTABLE=$PYTHON    \
+      $SRC_DIR
 
 make install


### PR DESCRIPTION
Fixes #157.

I am not bumbing the build number because this should have no impact on the resulting binary.